### PR TITLE
Update project title in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# DaigakunoiikangiOS - Focus Platform (Flutter + Rails)
+# DaigakunoiikangiOS - Focus Platform (Flutter + Rails+Rustproxy)
 @
 このプロジェクトは、**Flutter** (マルチプラットフォーム・クライアント) と **Ruby on Rails** (中央同期サーバー) で構築された、プレミアムな集中・習慣化プラットフォームです。旧ネイティブ版から完全に移行し、単一のコードベースで高度なゲーミフィケーションを提供します!
 ※まだまだ調整中です


### PR DESCRIPTION
This pull request makes a minor update to the project documentation, reflecting a change in the technology stack.

* The project title in `README.md` was updated to include `Rustproxy`, indicating that the platform now uses Rust as part of its backend in addition to Flutter and Rails.